### PR TITLE
Update for 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.5",
-        "govcms/govcms": "~1.0"
+        "govcms/govcms": "~1.0",
+	"symfony/event-dispatcher": "4.3.11 as 3.4.35"
     },
     "require-dev": {
         "drush/drush": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php": "^7.3",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.5",
-        "govcms/govcms": "~1.0",
-	"symfony/event-dispatcher": "4.3.11 as 3.4.35"
+        "govcms/govcms": "~1",
+        "symfony/event-dispatcher": "4.3.11 as 3.4.35"
     },
     "require-dev": {
         "drush/drush": "^9.0"


### PR DESCRIPTION
* Updates requirement to PHP 7.3
* Adds `govcms/~1` instead of `govcms/~1.0` 
* Adds the fix for `event_dispatcher` which is reflected in the distribution.